### PR TITLE
Fix the docker compose instructions

### DIFF
--- a/docker-compose-no-vulnerability.yml
+++ b/docker-compose-no-vulnerability.yml
@@ -16,18 +16,15 @@ services:
     volumes:
       - minio_volume:/data
   db:
-    image: mysql/mysql-server:5.7.28
+    image: mysql:8.2.0
     restart: unless-stopped
     container_name: mlflow_db
     expose:
       - "3306"
     environment:
       - MYSQL_DATABASE=${MYSQL_DATABASE}
-      - MYSQL_USER=${MYSQL_USER}
-      - MYSQL_PASSWORD=${MYSQL_PASSWORD}
       - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
-    volumes:
-      - db_volume:/var/lib/mysql
+      - MYSQL_ROOT_HOST=%
     networks:
       - internal
   mlflow:
@@ -47,7 +44,7 @@ services:
     networks:
       - public
       - internal
-    entrypoint: mlflow server --backend-store-uri mysql+pymysql://${MYSQL_USER}:${MYSQL_PASSWORD}@db:3306/${MYSQL_DATABASE} --default-artifact-root s3://${AWS_BUCKET_NAME}/ --artifacts-destination s3://${AWS_BUCKET_NAME}/ -h 0.0.0.0
+    entrypoint: mlflow server --backend-store-uri mysql+pymysql://root:${MYSQL_ROOT_PASSWORD}@db:3306/${MYSQL_DATABASE} --default-artifact-root s3://${AWS_BUCKET_NAME}/ --artifacts-destination s3://${AWS_BUCKET_NAME}/ -h 0.0.0.0
     depends_on:
       wait-for-db:
         condition: service_completed_successfully

--- a/docker-compose-vulnerability.yml
+++ b/docker-compose-vulnerability.yml
@@ -16,18 +16,15 @@ services:
     volumes:
       - minio_volume:/data
   db:
-    image: mysql/mysql-server:5.7.28
+    image: mysql:8.2.0
     restart: unless-stopped
     container_name: mlflow_db
     expose:
       - "3306"
     environment:
       - MYSQL_DATABASE=${MYSQL_DATABASE}
-      - MYSQL_USER=${MYSQL_USER}
-      - MYSQL_PASSWORD=${MYSQL_PASSWORD}
       - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
-    volumes:
-      - db_volume:/var/lib/mysql
+      - MYSQL_ROOT_HOST=%
     networks:
       - internal
   mlflow:
@@ -47,7 +44,7 @@ services:
     networks:
       - public
       - internal
-    entrypoint: mlflow server --backend-store-uri mysql+pymysql://${MYSQL_USER}:${MYSQL_PASSWORD}@db:3306/${MYSQL_DATABASE} --default-artifact-root s3://${AWS_BUCKET_NAME}/ --artifacts-destination s3://${AWS_BUCKET_NAME}/ -h 0.0.0.0
+    entrypoint: mlflow server --backend-store-uri mysql+pymysql://root:${MYSQL_ROOT_PASSWORD}@db:3306/${MYSQL_DATABASE} --default-artifact-root s3://${AWS_BUCKET_NAME}/ --artifacts-destination s3://${AWS_BUCKET_NAME}/ -h 0.0.0.0
     depends_on:
       wait-for-db:
         condition: service_completed_successfully

--- a/mlflow-no-vuln/Dockerfile
+++ b/mlflow-no-vuln/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/mlflow/mlflow:v2.2.0
 
-RUN pip install boto3 pymysql
+RUN pip install boto3 pymysql cryptography
 
 ADD . /app
 WORKDIR /app

--- a/mlflow-vuln/Dockerfile
+++ b/mlflow-vuln/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/mlflow/mlflow:v2.0.0
 
-RUN pip install boto3 pymysql
+RUN pip install boto3 pymysql cryptography
 
 ADD . /app
 WORKDIR /app


### PR DESCRIPTION
While using this infrastructure for testing https://github.com/google/tsunami-security-scanner-plugins/pull/310, I run into a few issues. This PR should fix them, namely:
- The MySQL container was not reachable from other containers. I made it reachable everywhere and use the root directly;
- MLFlow requires cryptography, so it is now bundled when building the image.